### PR TITLE
[FEAT] GET 상세_상품 상세 조회 API 구현

### DIFF
--- a/src/main/java/sopt/org/CarrotServer/controller/sale/SaleController.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/SaleController.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 import sopt.org.CarrotServer.common.dto.ApiResponse;
 import sopt.org.CarrotServer.controller.sale.dto.request.CreateSaleRequestDto;
+import sopt.org.CarrotServer.controller.sale.dto.response.SaleDetailResponseDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleResponseDto;
 import sopt.org.CarrotServer.exception.SuccessStatus;
 import sopt.org.CarrotServer.service.sale.SaleService;
@@ -28,4 +29,12 @@ public class SaleController {
     public ApiResponse<List<SaleResponseDto>> getSales() {
         return ApiResponse.success(SuccessStatus.READ_ALL_SALE_SUCCESS, saleService.getSales());
     }
+
+    //[GET] 상세_상품 상세 조회
+    @GetMapping("/{saleId}")
+    public ApiResponse<SaleDetailResponseDto> getSaleById(@PathVariable final Long saleId) {
+        return ApiResponse.success(SuccessStatus.READ_SALE_DETAIL_SUCCESS, saleService.getSaleById(saleId));
+    }
+
+
 }

--- a/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleDetailDto.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleDetailDto.java
@@ -1,0 +1,38 @@
+package sopt.org.CarrotServer.controller.sale.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sopt.org.CarrotServer.domain.sale.Sale;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SaleDetailDto {
+    private Long saleId;
+    private String saleImgUrl;
+    private String title;
+    private String category;
+    private String time;
+    private Boolean isUpdated;
+    private Integer likeCount;
+    private Integer viewCount;
+    private String description;
+    private Boolean isCheckLike;
+    private Integer price;
+
+    public static SaleDetailDto of(Sale sale, Integer likeCount, Boolean isCheckLike) {
+        return new SaleDetailDto(
+                sale.getSaleId(),
+                sale.getSaleImgUrl(),
+                sale.getTitle(),
+                sale.getCategory(),
+                sale.getIsUpdated() ? sale.getModifiedAt() : sale.getCreatedAt(),
+                sale.getIsUpdated(),
+                likeCount,
+                sale.getView(),
+                sale.getDescription(),
+                isCheckLike,
+                sale.getPrice()
+        );
+    }
+}

--- a/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleDetailResponseDto.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleDetailResponseDto.java
@@ -1,0 +1,27 @@
+package sopt.org.CarrotServer.controller.sale.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sopt.org.CarrotServer.controller.user.dto.response.UserDetailResponseDto;
+import sopt.org.CarrotServer.domain.sale.Sale;
+import sopt.org.CarrotServer.domain.user.User;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SaleDetailResponseDto {
+
+    private SaleDetailDto sale;
+    private UserDetailResponseDto user;
+    private Long chatRoomId;
+
+    public static SaleDetailResponseDto of(Sale sale, Integer likeCount, Boolean isCheckLike, User user, Long chatRoomId) {
+        return new SaleDetailResponseDto(
+                SaleDetailDto.of(sale, likeCount, isCheckLike),
+                UserDetailResponseDto.of(user),
+                chatRoomId
+        );
+    }
+}
+
+

--- a/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleResponseDto.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleResponseDto.java
@@ -4,13 +4,11 @@ package sopt.org.CarrotServer.controller.sale.dto.response;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import sopt.org.CarrotServer.domain.sale.Sale;
-import sopt.org.CarrotServer.domain.sale.SaleStatus;
 
 @Getter
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 public class SaleResponseDto {
-    private Integer id;
+    private Long id;
     private String title;
     private String imgUrl;
     private String location;
@@ -21,9 +19,7 @@ public class SaleResponseDto {
     private Integer likeCount;
     private Boolean isCheckLike;
 
-
-
-    public static SaleResponseDto of(Integer id, String title, String imgUrl, String location, String time,
+    public static SaleResponseDto of(Long id, String title, String imgUrl, String location, String time,
                                      Boolean isUpdated, Integer price, Boolean isDiscount, Integer likeCount, Boolean isCheckLike) {
         return new SaleResponseDto(id, title, imgUrl, location, time, isUpdated, price, isDiscount, likeCount, isCheckLike);
     }

--- a/src/main/java/sopt/org/CarrotServer/controller/user/dto/response/UserDetailResponseDto.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/user/dto/response/UserDetailResponseDto.java
@@ -1,0 +1,26 @@
+package sopt.org.CarrotServer.controller.user.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sopt.org.CarrotServer.domain.user.User;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class UserDetailResponseDto {
+    private Long userId;
+    private String profileImgUrl;
+    private String nickname;
+    private String location;
+    private Double temperature;
+
+    public static UserDetailResponseDto of(User user) {
+        return new UserDetailResponseDto(
+                user.getUserId(),
+                user.getProfileImgUrl(),
+                user.getNickname(),
+                user.getLocation(),
+                user.getTemperature()
+        );
+    }
+}

--- a/src/main/java/sopt/org/CarrotServer/domain/sale/Sale.java
+++ b/src/main/java/sopt/org/CarrotServer/domain/sale/Sale.java
@@ -78,6 +78,9 @@ public class Sale extends BaseTimeEntity {
     @OneToMany(mappedBy = "sale", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ChatRoom> chatRoomList = new ArrayList<>();
 
+    @OneToMany(mappedBy = "sale",cascade = CascadeType.ALL, orphanRemoval = true)
+    private final List<SaleLike> saleLikeList = new ArrayList<>();
+
     //== 연관관계 메소드 ==//
     public void setUser(User user) {
         if (this.user != null) {

--- a/src/main/java/sopt/org/CarrotServer/domain/sale/SaleLike.java
+++ b/src/main/java/sopt/org/CarrotServer/domain/sale/SaleLike.java
@@ -33,4 +33,14 @@ public class SaleLike extends BaseTimeEntity {
         this.user = user;
         this.sale = sale;
     }
+
+    //== 연관관계 메소드 ==//
+    public void setSale(Sale sale) {
+        if (this.sale != null) {
+            this.sale.getSaleLikeList().remove(this);
+        }
+
+        this.sale = sale;
+        sale.getSaleLikeList().add(this);
+    }
 }

--- a/src/main/java/sopt/org/CarrotServer/exception/SuccessStatus.java
+++ b/src/main/java/sopt/org/CarrotServer/exception/SuccessStatus.java
@@ -22,10 +22,11 @@ public enum SuccessStatus {
 
     // User 관련
     CREATE_USER_SUCCESS(HttpStatus.CREATED, "유저 생성 성공"),
-    CREATE_SALE_SUCCESS(HttpStatus.CREATED, "상품 생성 성공"),
 
     // Sale 관련
-    READ_ALL_SALE_SUCCESS(HttpStatus.OK, "전체 상품 조회 성공");
+    CREATE_SALE_SUCCESS(HttpStatus.CREATED, "상품 생성 성공"),
+    READ_ALL_SALE_SUCCESS(HttpStatus.OK, "전체 상품 조회 성공"),
+    READ_SALE_DETAIL_SUCCESS(HttpStatus.OK, "상품 상세 조회 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sopt/org/CarrotServer/infrastructure/sale/SaleRepository.java
+++ b/src/main/java/sopt/org/CarrotServer/infrastructure/sale/SaleRepository.java
@@ -14,7 +14,6 @@ public interface SaleRepository extends Repository<Sale, Long> {
     // READ
     List<Sale> findAll();
     Optional<Sale> findById(Long id);
-
     // UPDATE
     // DELETE
 }

--- a/src/main/java/sopt/org/CarrotServer/service/sale/SaleService.java
+++ b/src/main/java/sopt/org/CarrotServer/service/sale/SaleService.java
@@ -4,6 +4,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import sopt.org.CarrotServer.controller.sale.dto.request.CreateSaleRequestDto;
+import sopt.org.CarrotServer.controller.sale.dto.response.SaleDetailResponseDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleResponseDto;
 import sopt.org.CarrotServer.domain.sale.Sale;
 import sopt.org.CarrotServer.domain.sale.SaleLikeId;
@@ -64,7 +65,7 @@ public class SaleService {
                     SaleLikeId.builder().saleId(sale.getSaleId()).userId(user.getUserId()).build());
 
             saleList.add(SaleResponseDto.of(
-                    Math.toIntExact(sale.getSaleId()),
+                    sale.getSaleId(),
                     sale.getTitle(),
                     sale.getSaleImgUrl(),
                     user.getLocation(),
@@ -80,11 +81,30 @@ public class SaleService {
         return saleList;
     }
 
-//    public List<PostResponseDto> getPostByUserId(final Long userId) {
-//        final List<PostResponseDto> postList = new ArrayList<>();
-//        postRepository.findAllByUserId(userId).forEach((p) ->
-//                postList.add(PostResponseDto.of(p.getId(), p.getTitle(), p.getContent()))
-//        );
-//        return postList;
-//    }
+    //상세_상품 상세 조회
+    public SaleDetailResponseDto getSaleById(final Long saleId) {
+        Sale sale = saleRepository.findById(saleId).orElseThrow(
+                () -> new NotFoundException(ErrorStatus.NO_EXISTS_SALE, ErrorStatus.NO_EXISTS_SALE.getMessage())
+        );
+
+        //TODO 로직이 겹치는데 어떻게 하는게 좋을지?
+        User user = userRepository.findById(sale.getUser().getUserId()).orElseThrow(
+                () -> new NotFoundException(ErrorStatus.NO_EXISTS_USER, ErrorStatus.NO_EXISTS_USER.getMessage())
+        );
+
+        //TODO 좋아요 수 계산을 sale.getSaleLikeList().size() 이렇게 해도 되는지?
+        int likeCount = Math.toIntExact(saleLikeRepository.countBySaleLikeIdSaleId(sale.getSaleId()));
+
+        //임시로 좋아요는 판매자가 눌렀는지 여부로 구현
+        boolean isCheckLike = saleLikeRepository.existsBySaleLikeId(
+                SaleLikeId.builder().saleId(sale.getSaleId()).userId(user.getUserId()).build());
+
+        Long chatRoomId = (long) -1; //채팅방이 존재하지 않는 경우 -1 리턴
+        if (!sale.getChatRoomList().isEmpty()) {
+            //상품의 첫번째 채팅방 아이디로 고정
+            chatRoomId = sale.getChatRoomList().get(0).getChatRoomId();
+        }
+
+        return SaleDetailResponseDto.of(sale, likeCount, isCheckLike, user, chatRoomId);
+    }
 }


### PR DESCRIPTION
## 관련 이슈
close #8

## 구현 명세
- 상세_상품 상세 조회 API를 구현했습니다.
- static메서드 of 반영했습니다!
- 채팅방이 존재하지 않는 경우 상품이 조회되지 않는건 어색할 것 같아서,
  만약 없다면 chatRoomId를 -1로 리턴하도록 구현했습니다
- 좋아요 카운트를 계산해야 하는데 sale_like 테이블에서 조회하지 않고,
   Sale 객체 내의 saleLikeList.size()값으로 사용해도 되는지 고민돼요,,