### PR TITLE
[FEAT] 상세_광고 조회 API 구현

### DIFF
--- a/src/main/java/sopt/org/CarrotServer/controller/sale/SaleController.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/SaleController.java
@@ -6,6 +6,7 @@ import sopt.org.CarrotServer.common.dto.ApiResponse;
 import sopt.org.CarrotServer.controller.sale.dto.request.CreateSaleRequestDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleDetailResponseDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleResponseDto;
+import sopt.org.CarrotServer.controller.sale.dto.response.SaleSimpleResponseDto;
 import sopt.org.CarrotServer.exception.SuccessStatus;
 import sopt.org.CarrotServer.service.sale.SaleService;
 
@@ -35,6 +36,16 @@ public class SaleController {
     public ApiResponse<SaleDetailResponseDto> getSaleById(@PathVariable final Long saleId) {
         return ApiResponse.success(SuccessStatus.READ_SALE_DETAIL_SUCCESS, saleService.getSaleById(saleId));
     }
+
+    //[GET] 상세_광고 조회
+    @GetMapping("/advertisement") //랜덤
+    public ApiResponse<SaleSimpleResponseDto> getRandomSale() {
+        return ApiResponse.success(SuccessStatus.READ_RANDOM_SALE_SUCCESS, saleService.getRandomSale());
+    }
+
+    //[GET] 상세_판매 상품 조회
+
+    //[GET] 상세_함께 본 상품 조회
 
 
 }

--- a/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleSimpleResponseDto.java
+++ b/src/main/java/sopt/org/CarrotServer/controller/sale/dto/response/SaleSimpleResponseDto.java
@@ -1,0 +1,26 @@
+package sopt.org.CarrotServer.controller.sale.dto.response;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import sopt.org.CarrotServer.domain.sale.Sale;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class SaleSimpleResponseDto {
+    private Long saleId;
+    private String saleImgUrl;
+    private String title;
+    private String nickname;
+    private Integer price;
+
+    public static SaleSimpleResponseDto of(Sale sale) {
+        return new SaleSimpleResponseDto(
+                sale.getSaleId(),
+                sale.getSaleImgUrl(),
+                sale.getTitle(),
+                sale.getUser().getNickname(),
+                sale.getPrice()
+        );
+    }
+}

--- a/src/main/java/sopt/org/CarrotServer/exception/SuccessStatus.java
+++ b/src/main/java/sopt/org/CarrotServer/exception/SuccessStatus.java
@@ -26,7 +26,8 @@ public enum SuccessStatus {
     // Sale 관련
     CREATE_SALE_SUCCESS(HttpStatus.CREATED, "상품 생성 성공"),
     READ_ALL_SALE_SUCCESS(HttpStatus.OK, "전체 상품 조회 성공"),
-    READ_SALE_DETAIL_SUCCESS(HttpStatus.OK, "상품 상세 조회 성공");
+    READ_SALE_DETAIL_SUCCESS(HttpStatus.OK, "상품 상세 조회 성공"),
+    READ_RANDOM_SALE_SUCCESS(HttpStatus.OK, "광고 조회 성공");
 
 
     private final HttpStatus httpStatus;

--- a/src/main/java/sopt/org/CarrotServer/infrastructure/sale/SaleRepository.java
+++ b/src/main/java/sopt/org/CarrotServer/infrastructure/sale/SaleRepository.java
@@ -1,10 +1,12 @@
 package sopt.org.CarrotServer.infrastructure.sale;
 
 import org.springframework.data.repository.Repository;
+import org.springframework.transaction.annotation.Transactional;
 import sopt.org.CarrotServer.domain.sale.Sale;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Random;
 
 public interface SaleRepository extends Repository<Sale, Long> {
 
@@ -13,7 +15,16 @@ public interface SaleRepository extends Repository<Sale, Long> {
 
     // READ
     List<Sale> findAll();
+
     Optional<Sale> findById(Long id);
+
+    //랜덤 조회 -> JPA는 주로 객체-관계 매핑(ORM)을 위한 기술로 랜덤 조회 기능 내장 x
+    //생쿼리는 객체지향 x -> default 메서드로 직접 구현
+    default Optional<Sale> findRandomSale() {
+        List<Sale> sales = findAll();
+        return Optional.ofNullable(sales.get(new Random().nextInt(sales.size())));
+    }
+
     // UPDATE
     // DELETE
 }

--- a/src/main/java/sopt/org/CarrotServer/service/sale/SaleService.java
+++ b/src/main/java/sopt/org/CarrotServer/service/sale/SaleService.java
@@ -6,6 +6,7 @@ import org.springframework.transaction.annotation.Transactional;
 import sopt.org.CarrotServer.controller.sale.dto.request.CreateSaleRequestDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleDetailResponseDto;
 import sopt.org.CarrotServer.controller.sale.dto.response.SaleResponseDto;
+import sopt.org.CarrotServer.controller.sale.dto.response.SaleSimpleResponseDto;
 import sopt.org.CarrotServer.domain.sale.Sale;
 import sopt.org.CarrotServer.domain.sale.SaleLikeId;
 import sopt.org.CarrotServer.domain.sale.SaleStatus;
@@ -107,4 +108,17 @@ public class SaleService {
 
         return SaleDetailResponseDto.of(sale, likeCount, isCheckLike, user, chatRoomId);
     }
+
+    //[GET] 상세_광고 조회
+    public SaleSimpleResponseDto getRandomSale() {
+        Sale sale = saleRepository.findRandomSale().orElseThrow(
+                () -> new NotFoundException(ErrorStatus.NO_EXISTS_SALE, ErrorStatus.NO_EXISTS_SALE.getMessage())
+        );
+
+        return SaleSimpleResponseDto.of(sale);
+    }
+    //[GET] 상세_판매 상품 조회
+
+    //[GET] 상세_함께 본 상품 조회
+
 }


### PR DESCRIPTION
## 관련 이슈
close #12 

## 구현 명세
- 광고로 한 개의 상품을 조회하는 API를 구현했습니다.
- 랜덤으로 하나를 뽑는 findRandom JPA는 내장되어 있지 않다고 해서,
  직접 default 메서드로 모든 상품을 조회하고 랜덤으로 상품 하나를 반환하는 식으로 구현했습니다.